### PR TITLE
mariadb works from 10.2.7 onward

### DIFF
--- a/master/installation.md
+++ b/master/installation.md
@@ -11,7 +11,7 @@ Before you install pixelfed, you will need to setup the required dependencies an
 Pixelfed has a few requirements you should be aware of before installing:
 
  - PHP >= 7.1.3 (7.2+ recommended for stable version)
- - MySQL >= 5.7, Postgres (MariaDB and sqlite are not supported yet)
+ - MySQL >= 5.7, Mariadb >= 10.2.7, Postgres (sqlite is not supported yet)
  - Redis
  - Composer
  - GD or ImageMagick


### PR DESCRIPTION
I assume the not supported status of MariaDB was due to missing JSON Data Type. That got introduced in 10.2.7 according to the docs[1] so it might make sense to update the documentation accordingly.

[1] https://mariadb.com/kb/en/library/json-data-type/