### PR TITLE
Nginx conf setting for client_max_body_size to avoid HTTP error 413 Request Entity Too Large

### DIFF
--- a/install-guides/arch.md
+++ b/install-guides/arch.md
@@ -98,6 +98,8 @@ events {
 }
 http {
     # [...]
+    client_max_body_size 9m; # add this line to configure client upload file size
+    
     gzip on;    # uncomment this line
 
     server {    # delete this entire block

--- a/running-pixelfed/installation.md
+++ b/running-pixelfed/installation.md
@@ -428,6 +428,10 @@ Make sure to use the `/public` folder as your server root. Example:`server {root
 If you set root to the install directory (example: `server {root /var/www/pixelfed;)` Pixelfed will not work.
 :::
 
+::: tip Nginx client max body size
+Make sure to set an appropriate `client_max_body_size` setting in the `nginx.conf` file. Set this slightly greater than your desired post size limit for file uploads. The `nginx.conf` file location will vary based on your server. `/etc/nginx/nginx.conf`
+Example:`http {client_max_body_size 9m;}`
+
 #### Obtaining an HTTPS certificate
 
 For testing deployments, you may generate a self-signed SSL certificate. For example:


### PR DESCRIPTION
Configure the Nginx "client_max_body_size" to avoid an HTTP error code 413 (Request Entity Too Large) response when uploading a photo.
https://nginx.org/en/docs/http/ngx_http_core_module.html#client_max_body_size
