### PR TITLE
Use 'main' branch instead of 'master' for editLink

### DIFF
--- a/.vuepress/config.js
+++ b/.vuepress/config.js
@@ -11,6 +11,7 @@ module.exports = {
   themeConfig: {
     logo: 'https://avatars0.githubusercontent.com/u/38410642?s=200&v=4',
     repo: 'pixelfed/docs',
+    docsBranch: 'main',
     editLinks: true,
     displayAllHeaders: false,
     sidebarDepth: 1,


### PR DESCRIPTION
Hi,

If one clicks any `Edit this page` link on https://docs.pixelfed.org/, gets 404 since the url redirects to `/master` branch. This should take of it and point to `/main` instead.