### PR TITLE
docs/make local development easier to use

### DIFF
--- a/content/en/developing-pixelfed/intro.md
+++ b/content/en/developing-pixelfed/intro.md
@@ -13,7 +13,11 @@ weight = 10
 - [PHP](https://www.php.net/manual/en/install.php)
 - [Composer](https://getcomposer.org/download/)
 - [Node](https://nodejs.org/en/download/)
-- [MySQL](https://www.mysql.com/downloads/) or [MariaDB](https://mariadb.org/download/?t=mariadb)
+- [npm](https://docs.npmjs.com/downloading-and-installing-node-js-and-npm)
+- Database
+  - [MariaDB](https://mariadb.org/download/?t=mariadb)
+  - [MySQL](https://www.mysql.com/downloads/)
+  - [PostgreSQL]https://www.postgresql.org/download/
 - [Redis](https://redis.io/docs/getting-started/)
 
 ## Development Setup
@@ -26,4 +30,4 @@ php artisan install
 php artisan serve
 ```
 
-The development server will start on: [http://localhost:8000](http://localhost:8000)
+The development server will start on: http://localhost:8000

--- a/content/en/developing-pixelfed/intro.md
+++ b/content/en/developing-pixelfed/intro.md
@@ -9,13 +9,12 @@ weight = 10
 +++
 
 ## Requirements
-- Git
-- PHP
-- Composer
-- Node
-- NPM
-- MySQL/MariaDB
-- Redis
+- [Git](https://git-scm.com/downloads)
+- [PHP](https://www.php.net/manual/en/install.php)
+- [Composer](https://getcomposer.org/download/)
+- [Node](https://nodejs.org/en/download/)
+- [MySQL](https://www.mysql.com/downloads/) or [MariaDB](https://mariadb.org/download/?t=mariadb)
+- [Redis](https://redis.io/docs/getting-started/)
 
 ## Development Setup
 For local/non-production use only.
@@ -25,6 +24,6 @@ cd pixelfed
 composer install
 php artisan install
 php artisan serve
-
-# Laravel development server started: http://127.0.0.1:8000
 ```
+
+The development server will start on: [http://localhost:8000](http://localhost:8000)

--- a/content/en/developing-pixelfed/intro.md
+++ b/content/en/developing-pixelfed/intro.md
@@ -14,6 +14,8 @@ weight = 10
 - Composer
 - Node
 - NPM
+- MySQL/MariaDB
+- Redis
 
 ## Development Setup
 For local/non-production use only.


### PR DESCRIPTION
- docs: explicitly declare datastore dependencies
- docs: add links to install guides for required dependencies
