### PR TITLE
docs/add how to for testing

### DIFF
--- a/content/en/developing-pixelfed/intro.md
+++ b/content/en/developing-pixelfed/intro.md
@@ -1,11 +1,11 @@
 +++
 title = "Setting up your environment"
 summary = "Download and install the pre-requisites, then run these commands."
+weight = 10
 [menu]
 [menu.docs]
 identifier = "development/intro"
 parent = "development"
-weight = 10
 +++
 
 ## Requirements

--- a/content/en/developing-pixelfed/testing.md
+++ b/content/en/developing-pixelfed/testing.md
@@ -1,0 +1,17 @@
++++
+title = "Running tests locally"
+summary = "Verify changes you are making using the automated test suites."
+weight = 11
+[menu]
+[menu.docs]
+identifier = "development/testing"
+parent = "development"
++++
+
+Currently there are tests in place for the Laravel components. These can be run with the following command.
+
+```bash
+php artisan test
+```
+
+Further reading: [Testing with Laravel](https://laravel.com/docs/testing)


### PR DESCRIPTION
- docs: add overview for running Laravel tests

This is not quite working as expected, even though this new page appears second in the sidebar order, the link at the base of the article indicates that the next page is the _Setting up your environment_

![Screenshot 2022-10-27 at 17 20 48](https://user-images.githubusercontent.com/472589/198330909-058f9e06-fc91-437c-ab21-f4253da2940f.jpg)

