### PR TITLE
Add page for Docker

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,14 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_size = 4
+indent_style = space
+insert_final_newline = true
+max_line_length = 80
+quote_style = single
+trim_trailing_whitespace = true
+
+[*.md]
+indent_size = 2

--- a/content/en/running-pixelfed/administration.md
+++ b/content/en/running-pixelfed/administration.md
@@ -1,7 +1,7 @@
 +++
 title = "Administering your website"
 summary = "Tips and instructions for managing your Pixelfed installation"
-weight = 30
+weight = 40
 [menu]
 [menu.docs]
 identifier = "admin/administration"
@@ -45,7 +45,7 @@ php artisan user:admin username_here
 You can run this command to fix accounts created before that username was reserved.
 ```bash
 php artisan fix:usernames
-``` 
+```
 
 ### Remove unused media
 

--- a/content/en/running-pixelfed/docker.md
+++ b/content/en/running-pixelfed/docker.md
@@ -1,0 +1,55 @@
++++
+title = "Using Docker"
+summary = "Leave the setup up to Docker."
+weight = 30
+[menu]
+[menu.docs]
+identifier = "admin/docker"
+parent = "admin"
++++
+
+{{<hint style="warning">}}
+**WARNING**
+
+Pixelfed is still a work in progress. We do not recommend running an instance in production at this stage unless you know what you are doing!
+{{</hint>}}
+
+## Setup
+
+Adjust `.env.docker` to how you want to run your instance:
+
+- Leave `APP_KEY` empty. This will be set automatically on the first run.
+- The Docker image has only been tested with MySQL and Redis. Use other databases and cache drivers at your own risk.
+
+## Build
+
+Our Docker image is built based on `contrib/docker/Dockerfile.apache`. (The FPM version is not up-to-date.)
+
+Uncomment the `build` property in the `pixelfed` and `pixelfed_worker` services in `docker-compose.yml` to build the image yourself, instead of using [the one from Docker Hub](https://hub.docker.com/r/pixelfed/pixelfed).
+
+## Run
+
+You'll need to run the image in two parallel containers, with these entrypoints:
+
+- `start.apache.sh` (default)
+- `worker.apache.sh`
+
+The easiest way to do this is to use [the provided `docker-compose.yml`](#docker-compose).
+
+### Docker Compose
+
+To build the images without running them yet (see [Build](#build)):
+
+```shell
+docker-compose --env-file=.env.docker build
+```
+
+To run Pixelfed:
+
+```shell
+docker-compose --env-file=.env.docker up
+```
+
+### Frontend Proxy
+
+To make your Pixelfed instance available on a public domain, you might want to consider a reverse proxy like [Traefik](https://github.com/traefik/traefik).

--- a/content/en/running-pixelfed/optional-features/_index.md
+++ b/content/en/running-pixelfed/optional-features/_index.md
@@ -1,7 +1,7 @@
 +++
 title = "Optional features"
 summary = "Functionality that can be optionally added to your Pixelfed website"
-weight = 40
+weight = 50
 [menu]
 [menu.docs]
 identifier = "admin/optional"

--- a/content/en/running-pixelfed/optional-features/ldap-authentication.md
+++ b/content/en/running-pixelfed/optional-features/ldap-authentication.md
@@ -1,7 +1,7 @@
 +++
 title = "LDAP Authentication"
 summary = "You can configure your Pixelfed server to authenticate with an LDAP Server!"
-weight = 43
+weight = 53
 [menu]
 [menu.docs]
 identifier = "admin/optional/ldap"
@@ -128,7 +128,7 @@ php artisan config:cache
 
 You are now ready to login via LDAP!
 
-To test your connection you can run 
+To test your connection you can run
 
 ```
 php artisan ldap:test

--- a/content/en/running-pixelfed/optional-features/livestreaming.md
+++ b/content/en/running-pixelfed/optional-features/livestreaming.md
@@ -1,7 +1,7 @@
 +++
 title = "Livestreaming (Pixelfed Live)"
 summary = "Pixelfed Live is a mobile based livestreaming feature."
-weight = 41
+weight = 51
 [menu]
 [menu.docs]
 identifier = "admin/optional/live"
@@ -38,11 +38,11 @@ rtmp {
             record off;
             interleave on;
             wait_key on;
-            
+
             deny play all;
 
             push rtmp://127.0.0.1:1935/hls-live flashver=FMLE/3.0;
-            
+
             on_publish http://localhost/api/live/broadcast/publish;
             on_publish_done http://localhost/api/live/broadcast/finish;
         }
@@ -57,7 +57,7 @@ rtmp {
             deny publish all;
 
             hls_path /home/pixelfed/storage/app/public/live-hls;
-        
+
             hls_nested on;
             hls_fragment 5s;
             hls_playlist_length 30s;

--- a/content/en/running-pixelfed/optional-features/websockets.md
+++ b/content/en/running-pixelfed/optional-features/websockets.md
@@ -1,7 +1,7 @@
 +++
 title = "Websockets"
 summary = "Websockets provide real time chat for Live Streaming and in the future, other aspects of the frontend UI and mobile apps."
-weight = 42
+weight = 52
 [menu]
 [menu.docs]
 identifier = "admin/optional/websockets"

--- a/content/en/running-pixelfed/troubleshooting.md
+++ b/content/en/running-pixelfed/troubleshooting.md
@@ -1,7 +1,7 @@
 +++
 title = "Troubleshooting"
 summary = "Frequently asked questions about things going wrong"
-weight = 50
+weight = 60
 [menu]
 [menu.docs]
 identifier = "admin/troubleshooting"


### PR DESCRIPTION
We're working on improving the Docker parts of Pixelfed, and I noticed there is no page for Docker in the docs. So I've added a first draft that matches the state of [this pull request](https://github.com/pixelfed/pixelfed/pull/4074).