### PR TITLE
Add troubleshooting instructions for mariadb on debian

### DIFF
--- a/running-pixelfed/troubleshooting.md
+++ b/running-pixelfed/troubleshooting.md
@@ -21,3 +21,6 @@ First, check that `OAUTH_ENABLE=1` is set in `.env`. If the problem persists, tr
 
 ## 419 Session Expired error
 Make sure you have `SESSION_DOMAIN`, `APP_URL` and `APP_DOMAIN` set in your `.env`.
+
+## Database migrations fail on debian / mariadb due to unknown charset
+Edit `/etc/mysql/mariadb.conf.d/50-server.cnf` and replace `character-set-collations = utf8mb4=uca1400_ai_ci` with `character-set-collations = utf8mb4=utf8mb4_unicode_ci`, then restart mariadb. Essentially mariadb on debian uses `uca1400_ai_ci` by default, when pixelfed expects `utf8mb4_unicode_ci`. You may need to `ALTER DATABASE <name> CHARACTER SET = 'utf8mb4_unicode_ci';` afterwards.


### PR DESCRIPTION
This is what I had to do and was stumped on this error:

```
php artisan migrate --force

   Illuminate\Database\QueryException 

  SQLSTATE[HY000] [2054] Server sent charset (0) unknown to the client. Please, report to the developers (Connection: mysql, SQL: select table_name as `name`, (data_length + index_length) as `size`, table_comment as `comment`, engine as `engine`, table_collation as `collation` from information_schema.tables where table_schema = 'pixelfed' and table_type in ('BASE TABLE', 'SYSTEM VERSIONED') order by table_name)

  at vendor/laravel/framework/src/Illuminate/Database/Connection.php:829
    825▕                     $this->getName(), $query, $this->prepareBindings($bindings), $e
    826▕                 );
    827▕             }
    828▕ 
  ➜ 829▕             throw new QueryException(
    830▕                 $this->getName(), $query, $this->prepareBindings($bindings), $e
    831▕             );
    832▕         }
    833▕     }

      +36 vendor frames 
  37  artisan:35
      Illuminate\Foundation\Console\Kernel::handle()
```

Turned out by default mariadb on debian 12 from the mariadb install guide uses a different character set.