### PR TITLE
Fix typo "recieve"

### DIFF
--- a/spec/ActivityPub.md
+++ b/spec/ActivityPub.md
@@ -1,6 +1,6 @@
 # ActivityPub
 
-A decentralized social networking protocol based upon the ActivityStreams 2.0 data format and JSON-LD. Pixelfed uses ActivityPub to send and recieve activities from other Pixelfed servers and other fediverse software like Mastodon.
+A decentralized social networking protocol based upon the ActivityStreams 2.0 data format and JSON-LD. Pixelfed uses ActivityPub to send and receive activities from other Pixelfed servers and other fediverse software like Mastodon.
 
 ## Context
 


### PR DESCRIPTION
"Rec*ie*ve" appears to have been an accidental misspelling of "rec*ei*ve", as shown on Wikipedia's Wiktionary [here](https://en.wiktionary.org/wiki/recieve).

Thank you for all of your work on the Fediverse! I have a weird habit of idly navigating open-source websites then finding spelling mistakes / dead links, and this is one such occasion.