### PR TITLE
Add the Code of Conduct

### DIFF
--- a/.vitepress/config.mjs
+++ b/.vitepress/config.mjs
@@ -31,6 +31,7 @@ export default defineConfig({
         text: '',
         items: [
           { text: 'Introduction', link: '/project/introduction' },
+          { text: 'Code of Conduct', link: '/CODE_OF_CONDUCT' },
           { text: 'Community', link: '/project/community' },
         ]
       },


### PR DESCRIPTION
This adds the code of conduct to the documentation site.

Fixes https://github.com/pixelfed/docs/issues/133

![grafik](https://github.com/user-attachments/assets/ec0a0e69-9e39-4507-96a8-8cc0ee9d1745)
