### PR TITLE
Pixelfed composer requires php8.3 now, and not 8.2

### DIFF
--- a/running-pixelfed/prerequisites.md
+++ b/running-pixelfed/prerequisites.md
@@ -34,7 +34,7 @@ This doesn't necessarily mean you need a VPS. Some shared hosts give you SSH acc
 
 ## PHP-FPM
 
-You can check your currently installed version of PHP-FPM by running `php-fpm -v`. Make sure you are running **PHP >= 8.2**.
+You can check your currently installed version of PHP-FPM by running `php-fpm -v`. Make sure you are running **PHP >= 8.3**.
 
 You can check your currently loaded extensions by running `php-fpm -m`. Modules are usually enabled by editing your PHP configuration file and uncommenting the appropriate lines under the "Dynamic extensions" section. Make sure the following extensions are installed and loaded:
 


### PR DESCRIPTION
  Problem 1
    - laravel-notification-channels/expo is locked to version v2.0.0 and an update of this package was not requested.
    - laravel-notification-channels/expo v2.0.0 requires php ~8.3 -> your php version (8.2.27) does not satisfy that requirement.