### PR TITLE
Change service restart policy to always

### DIFF
--- a/running-pixelfed/installation.md
+++ b/running-pixelfed/installation.md
@@ -295,7 +295,7 @@ Requires=nginx
 Type=simple
 ExecStart=/usr/bin/php /usr/share/webapps/pixelfed/artisan horizon
 User=http
-Restart=on-failure
+Restart=always
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Because else `horizon:terminate` can silently stop the service.